### PR TITLE
Minor edits to firemaking, see details

### DIFF
--- a/minions.md
+++ b/minions.md
@@ -177,12 +177,11 @@ Wintertodt might get released later!
 ### Logs
 | Log | Required level |
 | - | :-: |
-| Tree | 1 |
-| Achey | 1 |
+| Logs | 1 |
 | Oak | 15 |
 | Willow | 30 |
 | Teak | 35 |
-| Arctic pine | 42 |
+| Arctic pine logs | 42 |
 | Maple | 45 |
 | Mahogany | 50 |
 | Yew | 60 |


### PR DESCRIPTION
Achey logs are not compatible with +light at the moment. Removing. Changed "tree" to logs in firemaking table, as you're not lighting a tree, you're lighting logs. Changed arctic pine to arctic pine logs, as that's the name required for lighting them.